### PR TITLE
Fix iOS Delay of 300ms on Touch Event

### DIFF
--- a/src/components/segment/segment-button.ts
+++ b/src/components/segment/segment-button.ts
@@ -86,8 +86,8 @@ export class SegmentButton {
    * @hidden
    * On click of a SegmentButton
    */
-  @HostListener('click')
-  onClick() {
+  @HostListener('tap')
+  onTap() {
     console.debug('SegmentButton, select', this.value);
     this.ionSelect.emit(this);
   }


### PR DESCRIPTION
#### Short description of what this resolves:

I had problems with delays of 300ms with click events when I build for iOS using ion-segment.

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
